### PR TITLE
Handle failed to converge Voc simulation in impedance.py

### DIFF
--- a/pySIMsalabim/experiments/impedance.py
+++ b/pySIMsalabim/experiments/impedance.py
@@ -695,7 +695,7 @@ def run_impedance_simu(zimt_device_parameters, session_path, f_min, f_max, f_ste
             else:
                 result, message = utils_gen.run_simulation('zimt', Impedance_SS_args, session_path, run_mode)
     
-            if result.returncode == 0 or result.returncode == 95:
+            if result.returncode == 0: # If result.returncode == 95, than one point failed to converge: Voc, so stop this simulation
                 data = read_tj_file(session_path, tj_file_name=tj_name)
                 
                 V_0 = data['Vext'][0]
@@ -943,9 +943,11 @@ if __name__ == "__main__":
                                          output_file=output_name, tj_name=tJFile, varFile=varFile, ini_timeFactor=ini_timeFactor, timeFactor=timeFactor, cmd_pars=cmd_pars, UUID=UUID)
 
     # Make the impedance plots
-    if result == 0 or result == 95:
+    calc_Voc_output_string = 'Computing the value of Voc led to the following error:'
+    if result == 0:
         plot_impedance(session_path, os.path.basename(output_name))
+    elif result.returncode == 95 and calc_Voc_output_string not in message:
+	plot_impedance(session_path, os.path.basename(output_name))
     else:
         print(message)
         sys.exit(1)
-


### PR DESCRIPTION
When computing the value for Voc if V_0 == 'oc' and if result.returncode == 95, than one point failed to converge. Since this one point can only be Voc, stop the whole impedance simulation