### PR TITLE
Update utils.py

### DIFF
--- a/pySIMsalabim/utils/utils.py
+++ b/pySIMsalabim/utils/utils.py
@@ -121,9 +121,11 @@ def update_cmd_pars(main_pars, cmd_pars):
         for main in main_pars:
             if par['par'] == main['par']:
                 main['val'] = str(par['val']) # convert to string
+                found = True
                 break
         if not found:
             main_pars.append(par)          
     
     return main_pars
+
 


### PR DESCRIPTION
Update cmd_pars properly. Overwrite mandatory options for ZimT with user-defined input. If e.g. in both Impedance_args as the cmd-line 'limitDigits' is defined, use the limitDigits as defined by the user. Without using this line, if an option is defined in by both the user and the Impedance_args, the simulation won't run, as the option will be written twice on the ./zimt cmd-line. E.g. "./zimt -limitDigits 0 -limitDigits 1"